### PR TITLE
Bug 962913 - Ability to recursively copy directories over built profiles in tests

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+# 0.4.0
+  - add extracts feature
+
 # 0.3.0
   - symlink app contents rather then copying them [massive perf win]
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ var options = {
   // also apps can be preloaded (packaged apps)
   apps: {
     'origin-for-my-app.com': '/path/to/app'
-  }
+  },
+
+  // copy files into profile once it has been created. Used for
+  // copying prebuilt databases and other files into profiles.
+  extracts: '/path/to/extract/dir'
 };
 
 profile.create(options, function(err, instance) {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ var Profile = require('./lib/profile'),
 var OPTIONS = {
   'apps': './lib/options/apps',
   'prefs': './lib/options/prefs',
-  'settings': './lib/options/settings'
+  'settings': './lib/options/settings',
+  'extracts': './lib/options/extracts'
 };
 
 /**

--- a/lib/options/extracts.js
+++ b/lib/options/extracts.js
@@ -1,0 +1,28 @@
+var fse = require('fs-extra');
+
+/**
+ * Recursively copy a directory of prebuilt files into a profile. Used for
+ * overwriting files in a clean profile for tests.
+ *
+ * Options:
+ *  - (Object) extract: Directory to copy into profile.
+ *
+ * @param {String} profile path to profile.
+ * @param {Object} options for directory.
+ * @param {Function} callback fires after successfully copying.
+ */
+function copyExtract(profile, options, callback) {
+  // we userPrefs was used in the past
+  var extractsDir = options.extracts;
+  // don't do anything unless there is a directory to copy
+  if (!extractsDir) {
+    return process.nextTick(callback.bind(null, null, profile));
+  }
+
+  fse.copy(extractsDir, profile, function(err) {
+    if (err) return callback(err);
+    return callback(null, profile);
+  });
+}
+
+module.exports = copyExtract;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mozilla-profile-builder",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "James Lal [:lightsofapollo]",
   "description": "Create profiles for firefox/b2g desktop",
   "main": "index.js",
@@ -14,7 +14,8 @@
     "tmp": "~0.0.21",
     "remove": "~0.1",
     "packaged-webapp": "~0.1.1",
-    "traverse-directory": "~0.1.0"
+    "traverse-directory": "~0.1.0",
+    "fs-extra": "~0.8.1"
   },
   "devDependencies": {
     "mocha": "~1.7",
@@ -24,8 +25,11 @@
   "engine": {
     "node": ">=0.4"
   },
-
   "scripts": {
     "test": "make test"
+  },
+  "repository" :
+  { "type" : "git"
+  , "url" : "http://github.com/mozilla-b2g/mozilla-profile-builder.git"
   }
 }


### PR DESCRIPTION
I'm calling this "extracts" because the idea is that you can build a profile, run B2G Desktop and manually do things, then "extract" the files you need from the profile to store in another directory, and have them copied over to an otherwise clean profile when an integration test runs. For instance, this means we can prefill some localStorage values for apps, and copy the IDB file over an otherwise pristine profile to test version upgrades.
